### PR TITLE
refactor(domain): migrate SharedKernel to Domain.Common

### DIFF
--- a/Elevator-Management-Simulator.sln
+++ b/Elevator-Management-Simulator.sln
@@ -15,8 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{64A28C1B-09AF-426E-8721-D002BE554B48}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedKernel", "src\SharedKernel\SharedKernel.csproj", "{166778A2-518F-47F0-BBC7-DB49C76A963C}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Domain", "src\Domain\Domain.csproj", "{6448ADE8-34BC-4F2F-A68C-5B2D6BF4FB0B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Application", "src\Application\Application.csproj", "{0F576D4A-156D-4626-A4D5-83DD0F6FAFE7}"
@@ -35,18 +33,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationTests", "tests\A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfrastructureTests", "tests\InfrastructureTests\InfrastructureTests.csproj", "{D31CC13B-83C1-4049-97EC-A2275E9DCEA4}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{FBE26A94-8284-4449-BC37-84359EBE04C1}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{166778A2-518F-47F0-BBC7-DB49C76A963C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{166778A2-518F-47F0-BBC7-DB49C76A963C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{166778A2-518F-47F0-BBC7-DB49C76A963C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{166778A2-518F-47F0-BBC7-DB49C76A963C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6448ADE8-34BC-4F2F-A68C-5B2D6BF4FB0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6448ADE8-34BC-4F2F-A68C-5B2D6BF4FB0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6448ADE8-34BC-4F2F-A68C-5B2D6BF4FB0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -92,7 +84,6 @@ Global
 		{CC90FD89-179C-48B0-A1DE-689BB734EF2F} = {64A28C1B-09AF-426E-8721-D002BE554B48}
 		{D512C1FB-EEA1-4A64-8678-B12959F51EE2} = {1EB88D85-BE1E-46DE-99A2-2F02363060AF}
 		{D31CC13B-83C1-4049-97EC-A2275E9DCEA4} = {1EB88D85-BE1E-46DE-99A2-2F02363060AF}
-		{166778A2-518F-47F0-BBC7-DB49C76A963C} = {FBE26A94-8284-4449-BC37-84359EBE04C1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B948A3CC-9872-4612-ABD2-BB3D49671542}

--- a/src/Application/Abstractions/Behaviors/RequestLoggingPipelineBehavior.cs
+++ b/src/Application/Abstractions/Behaviors/RequestLoggingPipelineBehavior.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
 using Microsoft.Extensions.Logging;
 using Serilog.Context;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Abstractions.Behaviors;
 

--- a/src/Application/Abstractions/Behaviors/ValidationPipelineBehavior.cs
+++ b/src/Application/Abstractions/Behaviors/ValidationPipelineBehavior.cs
@@ -2,7 +2,7 @@
 using FluentValidation;
 using FluentValidation.Results;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Abstractions.Behaviors;
 

--- a/src/Application/Abstractions/Messaging/ICommand.cs
+++ b/src/Application/Abstractions/Messaging/ICommand.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Abstractions.Messaging;
 

--- a/src/Application/Abstractions/Messaging/ICommandHandler.cs
+++ b/src/Application/Abstractions/Messaging/ICommandHandler.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Abstractions.Messaging;
 

--- a/src/Application/Abstractions/Messaging/IQuery.cs
+++ b/src/Application/Abstractions/Messaging/IQuery.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Abstractions.Messaging;
 

--- a/src/Application/Abstractions/Messaging/IQueryHandler.cs
+++ b/src/Application/Abstractions/Messaging/IQueryHandler.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Abstractions.Messaging;
 

--- a/src/Application/Abstractions/Screen/IScreen.cs
+++ b/src/Application/Abstractions/Screen/IScreen.cs
@@ -1,4 +1,4 @@
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Abstractions.Screen;
 

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
-    <ProjectReference Include="..\SharedKernel\SharedKernel.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,6 +20,10 @@
 
   <ItemGroup>
 	<InternalsVisibleTo Include="Application.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Building\" />
   </ItemGroup>
 
 </Project>

--- a/src/Application/Todos/Complete/CompleteTodoCommandHandler.cs
+++ b/src/Application/Todos/Complete/CompleteTodoCommandHandler.cs
@@ -3,7 +3,7 @@ using Application.Abstractions.Data;
 using Application.Abstractions.Messaging;
 using Domain.Todos;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Todos.Complete;
 

--- a/src/Application/Todos/Create/CreateTodoCommandHandler.cs
+++ b/src/Application/Todos/Create/CreateTodoCommandHandler.cs
@@ -4,7 +4,7 @@ using Application.Abstractions.Messaging;
 using Domain.Todos;
 using Domain.Users;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Todos.Create;
 

--- a/src/Application/Todos/Delete/DeleteTodoCommandHandler.cs
+++ b/src/Application/Todos/Delete/DeleteTodoCommandHandler.cs
@@ -3,7 +3,7 @@ using Application.Abstractions.Data;
 using Application.Abstractions.Messaging;
 using Domain.Todos;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Todos.Delete;
 

--- a/src/Application/Todos/Get/GetTodosQueryHandler.cs
+++ b/src/Application/Todos/Get/GetTodosQueryHandler.cs
@@ -3,7 +3,7 @@ using Application.Abstractions.Data;
 using Application.Abstractions.Messaging;
 using Domain.Users;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Todos.Get;
 

--- a/src/Application/Todos/GetById/GetTodoByIdQueryHandler.cs
+++ b/src/Application/Todos/GetById/GetTodoByIdQueryHandler.cs
@@ -3,7 +3,7 @@ using Application.Abstractions.Data;
 using Application.Abstractions.Messaging;
 using Domain.Todos;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Todos.GetById;
 

--- a/src/Application/Users/GetByEmail/GetUserByEmailQueryHandler.cs
+++ b/src/Application/Users/GetByEmail/GetUserByEmailQueryHandler.cs
@@ -3,7 +3,7 @@ using Application.Abstractions.Data;
 using Application.Abstractions.Messaging;
 using Domain.Users;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Users.GetByEmail;
 

--- a/src/Application/Users/GetById/GetUserByIdQueryHandler.cs
+++ b/src/Application/Users/GetById/GetUserByIdQueryHandler.cs
@@ -3,7 +3,7 @@ using Application.Abstractions.Data;
 using Application.Abstractions.Messaging;
 using Domain.Users;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Users.GetById;
 

--- a/src/Application/Users/Login/LoginUserCommandHandler.cs
+++ b/src/Application/Users/Login/LoginUserCommandHandler.cs
@@ -3,7 +3,7 @@ using Application.Abstractions.Data;
 using Application.Abstractions.Messaging;
 using Domain.Users;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Users.Login;
 

--- a/src/Application/Users/Register/RegisterUserCommandHandler.cs
+++ b/src/Application/Users/Register/RegisterUserCommandHandler.cs
@@ -3,7 +3,7 @@ using Application.Abstractions.Data;
 using Application.Abstractions.Messaging;
 using Domain.Users;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Application.Users.Register;
 

--- a/src/Domain/Building/Building.cs
+++ b/src/Domain/Building/Building.cs
@@ -1,4 +1,4 @@
-using SharedKernel;
+using Domain.Common;
 
 namespace Domain.Users;
 

--- a/src/Domain/Common/AuditableEntity.cs
+++ b/src/Domain/Common/AuditableEntity.cs
@@ -1,4 +1,4 @@
-namespace SharedKernel;
+namespace Domain.Common;
 
 /// <summary> Base abstract class for entities that have audit and timestamp tracking. </summary>
 public abstract class AuditableEntity 

--- a/src/Domain/Common/Entity.cs
+++ b/src/Domain/Common/Entity.cs
@@ -1,4 +1,4 @@
-﻿namespace SharedKernel;
+﻿namespace Domain.Common;
 
 /// <summary> Base abstract class for entities which have domain events. </summary>
 public abstract class Entity

--- a/src/Domain/Common/Error.cs
+++ b/src/Domain/Common/Error.cs
@@ -1,4 +1,4 @@
-﻿namespace SharedKernel;
+﻿namespace Domain.Common;
 
 public record Error
 {

--- a/src/Domain/Common/ErrorType.cs
+++ b/src/Domain/Common/ErrorType.cs
@@ -1,4 +1,4 @@
-﻿namespace SharedKernel;
+﻿namespace Domain.Common;
 
 public enum ErrorType
 {

--- a/src/Domain/Common/IDateTimeProvider.cs
+++ b/src/Domain/Common/IDateTimeProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace SharedKernel;
+﻿namespace Domain.Common;
 
 public interface IDateTimeProvider
 {

--- a/src/Domain/Common/IDomainEvent.cs
+++ b/src/Domain/Common/IDomainEvent.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
 
-namespace SharedKernel;
+namespace Domain.Common;
 
 public interface IDomainEvent : INotification;

--- a/src/Domain/Common/ITimeAuditedEntity.cs
+++ b/src/Domain/Common/ITimeAuditedEntity.cs
@@ -1,4 +1,4 @@
-namespace SharedKernel;
+namespace Domain.Common;
 
 /// <summary> Describes database entities that tracks timestamps when data is modified. </summary>
 public interface ITimeAuditedEntity

--- a/src/Domain/Common/IUserAuditedEntity.cs
+++ b/src/Domain/Common/IUserAuditedEntity.cs
@@ -1,4 +1,4 @@
-namespace SharedKernel;
+namespace Domain.Common;
 
 /// <summary> Describes database entities that tracks users that modify data. </summary>
 public interface IUserAuditedEntity

--- a/src/Domain/Common/Result.cs
+++ b/src/Domain/Common/Result.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
-namespace SharedKernel;
+namespace Domain.Common;
 
 public class Result
 {

--- a/src/Domain/Common/ValidationError.cs
+++ b/src/Domain/Common/ValidationError.cs
@@ -1,4 +1,4 @@
-﻿namespace SharedKernel;
+﻿namespace Domain.Common;
 
 public sealed record ValidationError : Error
 {

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -1,7 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <ProjectReference Include="..\SharedKernel\SharedKernel.csproj" />
-  </ItemGroup>
-
+﻿<Project Sdk="Microsoft.NET.Sdk" >
+    <ItemGroup>
+    <PackageReference Include="MediatR" />
+    </ItemGroup>
 </Project>

--- a/src/Domain/Todos/TodoItem.cs
+++ b/src/Domain/Todos/TodoItem.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Domain.Todos;
 

--- a/src/Domain/Todos/TodoItemCompletedDomainEvent.cs
+++ b/src/Domain/Todos/TodoItemCompletedDomainEvent.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Domain.Todos;
 

--- a/src/Domain/Todos/TodoItemCreatedDomainEvent.cs
+++ b/src/Domain/Todos/TodoItemCreatedDomainEvent.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Domain.Todos;
 

--- a/src/Domain/Todos/TodoItemDeletedDomainEvent.cs
+++ b/src/Domain/Todos/TodoItemDeletedDomainEvent.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Domain.Todos;
 

--- a/src/Domain/Todos/TodoItemErrors.cs
+++ b/src/Domain/Todos/TodoItemErrors.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Domain.Todos;
 

--- a/src/Domain/Users/User.cs
+++ b/src/Domain/Users/User.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Domain.Users;
 

--- a/src/Domain/Users/UserErrors.cs
+++ b/src/Domain/Users/UserErrors.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Domain.Users;
 

--- a/src/Domain/Users/UserRegisteredDomainEvent.cs
+++ b/src/Domain/Users/UserRegisteredDomainEvent.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Domain.Users;
 

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -14,7 +14,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
-using SharedKernel;
+using Domain.Common;
 
 namespace Infrastructure;
 

--- a/src/Infrastructure/Persistence/Database/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/Database/ApplicationDbContext.cs
@@ -2,7 +2,7 @@
 using Domain.Users;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using SharedKernel;
+using Domain.Common;
 
 namespace Infrastructure.Database;
 

--- a/src/Infrastructure/Persistence/DatabaseConfiguration/BuildingConfiguration.cs
+++ b/src/Infrastructure/Persistence/DatabaseConfiguration/BuildingConfiguration.cs
@@ -1,0 +1,20 @@
+using Domain.Users;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Users;
+
+internal sealed class BuildingConfiguration : IEntityTypeConfiguration<Building>
+{
+    public void Configure(EntityTypeBuilder<Building> builder)
+    {
+        builder.HasKey(b => b.Id);
+
+        builder.HasIndex(b => b.Name).IsUnique();
+        //
+        // builder.HasMany(b => b.Users)
+        //     .WithOne(u => u.Building)
+        //     .HasForeignKey(u => u.BuildingId)
+        //     .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Infrastructure/Persistence/Interceptors/DispatchDomainEventsInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/DispatchDomainEventsInterceptor.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using SharedKernel;
+using Domain.Common;
 
 namespace Infrastructure.Persistance.Interceptors;
 

--- a/src/Infrastructure/Time/DateTimeProvider.cs
+++ b/src/Infrastructure/Time/DateTimeProvider.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Infrastructure.Time;
 

--- a/src/Presentation/Extensions/CustomResults.cs
+++ b/src/Presentation/Extensions/CustomResults.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Http;
-using SharedKernel;
+using Domain.Common;
 
 namespace Presentation.Extensions;
 

--- a/src/Presentation/Extensions/ResultExtensions.cs
+++ b/src/Presentation/Extensions/ResultExtensions.cs
@@ -1,4 +1,4 @@
-using SharedKernel;
+using Domain.Common;
 
 namespace Presentation.Extensions;
 

--- a/src/Presentation/Screens/LoginScreen.cs
+++ b/src/Presentation/Screens/LoginScreen.cs
@@ -2,7 +2,7 @@ using Application.Abstractions.Screen;
 using Application.Users.Login;
 using MediatR;
 using Presentation.Extensions;
-using SharedKernel;
+using Domain.Common;
 using Spectre.Console;
 
 namespace Presentation.Screens;

--- a/src/Presentation/Screens/MenuScreen.cs
+++ b/src/Presentation/Screens/MenuScreen.cs
@@ -1,7 +1,7 @@
 using Spectre.Console;
 using Application.Abstractions.Screen;
 using Application.Screens;
-using SharedKernel;
+using Domain.Common;
 
 namespace Presentation.Screens;
 

--- a/src/Presentation/Screens/RegisterScreen.cs
+++ b/src/Presentation/Screens/RegisterScreen.cs
@@ -3,7 +3,7 @@ using Application.Users.Register;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Presentation.Extensions;
-using SharedKernel;
+using Domain.Common;
 using Spectre.Console;
 
 namespace Presentation.Screens;

--- a/src/SharedKernel/SharedKernel.csproj
+++ b/src/SharedKernel/SharedKernel.csproj
@@ -1,7 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <PackageReference Include="MediatR.Contracts" />
-  </ItemGroup>
-
-</Project>

--- a/src/Web.Api/Endpoints/Todos/Complete.cs
+++ b/src/Web.Api/Endpoints/Todos/Complete.cs
@@ -1,7 +1,7 @@
 ﻿using Application.Todos.Complete;
 using Application.Todos.Delete;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 using Web.Api.Extensions;
 using Web.Api.Infrastructure;
 

--- a/src/Web.Api/Endpoints/Todos/Create.cs
+++ b/src/Web.Api/Endpoints/Todos/Create.cs
@@ -1,7 +1,7 @@
 ﻿using Application.Todos.Create;
 using Domain.Todos;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 using Web.Api.Extensions;
 using Web.Api.Infrastructure;
 

--- a/src/Web.Api/Endpoints/Todos/Delete.cs
+++ b/src/Web.Api/Endpoints/Todos/Delete.cs
@@ -1,6 +1,6 @@
 ﻿using Application.Todos.Delete;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 using Web.Api.Extensions;
 using Web.Api.Infrastructure;
 

--- a/src/Web.Api/Endpoints/Todos/Get.cs
+++ b/src/Web.Api/Endpoints/Todos/Get.cs
@@ -1,6 +1,6 @@
 ﻿using Application.Todos.Get;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 using Web.Api.Extensions;
 using Web.Api.Infrastructure;
 

--- a/src/Web.Api/Endpoints/Todos/GetById.cs
+++ b/src/Web.Api/Endpoints/Todos/GetById.cs
@@ -1,6 +1,6 @@
 ﻿using Application.Todos.GetById;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 using Web.Api.Extensions;
 using Web.Api.Infrastructure;
 

--- a/src/Web.Api/Endpoints/Users/GetById.cs
+++ b/src/Web.Api/Endpoints/Users/GetById.cs
@@ -1,6 +1,6 @@
 ﻿using Application.Users.GetById;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 using Web.Api.Extensions;
 using Web.Api.Infrastructure;
 

--- a/src/Web.Api/Endpoints/Users/Login.cs
+++ b/src/Web.Api/Endpoints/Users/Login.cs
@@ -1,6 +1,6 @@
 ﻿using Application.Users.Login;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 using Web.Api.Extensions;
 using Web.Api.Infrastructure;
 

--- a/src/Web.Api/Endpoints/Users/Register.cs
+++ b/src/Web.Api/Endpoints/Users/Register.cs
@@ -1,6 +1,6 @@
 ﻿using Application.Users.Register;
 using MediatR;
-using SharedKernel;
+using Domain.Common;
 using Web.Api.Extensions;
 using Web.Api.Infrastructure;
 

--- a/src/Web.Api/Extensions/ResultExtensions.cs
+++ b/src/Web.Api/Extensions/ResultExtensions.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Web.Api.Extensions;
 

--- a/src/Web.Api/Infrastructure/CustomResults.cs
+++ b/src/Web.Api/Infrastructure/CustomResults.cs
@@ -1,4 +1,4 @@
-﻿using SharedKernel;
+﻿using Domain.Common;
 
 namespace Web.Api.Infrastructure;
 

--- a/tests/ApplicationTests/Users/GetUserByIdQueryHandlerTests.cs
+++ b/tests/ApplicationTests/Users/GetUserByIdQueryHandlerTests.cs
@@ -5,7 +5,7 @@ using Infrastructure.Database;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
-using SharedKernel;
+using Domain.Common;
 
 namespace ApplicationTests.Users;
 

--- a/tests/ArchitectureTests/ArchitectureTests.csproj
+++ b/tests/ArchitectureTests/ArchitectureTests.csproj
@@ -29,7 +29,6 @@
     <ProjectReference Include="..\..\src\Domain\Domain.csproj" />
     <ProjectReference Include="..\..\src\Infrastructure\Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Presentation\Presentation.csproj" />
-    <ProjectReference Include="..\..\src\SharedKernel\SharedKernel.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Remove `SharedKernel` project and refactor code to use `Domain.Common` namespace. Update references across the codebase to maintain functionality. This change simplifies the project structure and improves the clarity of domain-related entities.