### PR TITLE
feat(menu): add multi-request elevator control option

### DIFF
--- a/src/Application/Screens/MenuSelection.cs
+++ b/src/Application/Screens/MenuSelection.cs
@@ -10,5 +10,7 @@ public enum MenuSelection
     /// <summary> Dashboard </summary>
     Dashboard,
     /// <summary> ElevatorControl </summary>
-    ElevatorControl
+    ElevatorControl,
+    //Multi Request Elevator Control
+    MultiElevatorControl
 }

--- a/src/Infrastructure/Services/ElevatorSimulationHostedService.cs
+++ b/src/Infrastructure/Services/ElevatorSimulationHostedService.cs
@@ -35,8 +35,12 @@ public class ElevatorSimulationHostedService(
                     continue;
                 }
 
-                foreach (var elevator in elevatorsResult.Value)
+                foreach (var elevator in elevatorsResult.Value.AsParallel())
                 {
+                    logger.LogInformation(
+                        "Simulating elevator {ElevatorId} on floor {Floor}",
+                        elevator.Id, elevator.CurrentFloor);
+                    
                     var elevatorChanged = true;
                     if (elevator.ElevatorStatus != ElevatorStatus.Active)
                     {
@@ -48,23 +52,9 @@ public class ElevatorSimulationHostedService(
                     {
                         case ElevatorDirection.Up:
                             elevator.CurrentFloor += elevator.FloorsPerSecond;
-                            // //Simulate hard break!
-                            // if (elevator.CurrentFloor >= elevator.DestinationFloor)
-                            // {
-                            //     elevator.CurrentFloor = elevator.DestinationFloor;
-                            //     elevator.ElevatorDirection = ElevatorDirection.None;
-                            //     elevator.DoorStatus = ElevatorDoorStatus.Open;
-                            // }
                             break;
                         case ElevatorDirection.Down:
                             elevator.CurrentFloor -= elevator.FloorsPerSecond;
-                            //Simulate hard break!
-                            // if (elevator.CurrentFloor <= elevator.DestinationFloor)
-                            // {
-                            //     elevator.CurrentFloor = elevator.DestinationFloor;
-                            //     elevator.ElevatorDirection = ElevatorDirection.None;
-                            //     elevator.DoorStatus = ElevatorDoorStatus.Open;
-                            // }
                             break;
                         case ElevatorDirection.None:
                             {

--- a/src/Presentation/App.cs
+++ b/src/Presentation/App.cs
@@ -11,7 +11,7 @@ namespace Presentation;
 // A hosted service that can be run by the Host
 // This could be replaced by more complex logic such as background tasks, 
 // scheduled jobs, or other application logic
-public class App(IServiceProvider serviceProvider) : IHostedService
+public class App(IServiceProvider serviceProvider,IHostApplicationLifetime applicationLifetime) : IHostedService
 {
     // This method is called when the host starts
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -46,6 +46,10 @@ public class App(IServiceProvider serviceProvider) : IHostedService
                     var elevatorControlScreen = serviceProvider.GetRequiredService<ElevatorControlScreen>();
                     await elevatorControlScreen.ShowAsync(cancellationToken);
                     break;
+                case MenuSelection.MultiElevatorControl:
+                    var multiElevatorControlScreen = serviceProvider.GetRequiredService<ElevatorControlMultipleRequestScreen>();
+                    await multiElevatorControlScreen.ShowAsync(cancellationToken);
+                    break;
             }
             
             AnsiConsole.Clear();
@@ -68,6 +72,7 @@ public class App(IServiceProvider serviceProvider) : IHostedService
     public Task StopAsync(CancellationToken cancellationToken)
     {
         AnsiConsole.MarkupLine("[grey]Shutting down App...[/]");
-        throw new OperationCanceledException("App is shutting down");
+        applicationLifetime.StopApplication();
+        return Task.CompletedTask;
     }
 }

--- a/src/Presentation/DependencyInjections.cs
+++ b/src/Presentation/DependencyInjections.cs
@@ -24,6 +24,7 @@ public static class DependencyInjections
          services.AddTransient<LoginScreen>();
          services.AddTransient<DashboardScreen>();
          services.AddTransient<ElevatorControlScreen>();
+         services.AddTransient<ElevatorControlMultipleRequestScreen>();
          return services;
     }
     

--- a/src/Presentation/Screens/MenuScreen.cs
+++ b/src/Presentation/Screens/MenuScreen.cs
@@ -10,11 +10,11 @@ public class MenuScreen : IScreen<MenuSelection>
 {
     private static readonly Dictionary<string, MenuSelection> MenuOptions = new()
     {
-        ["Login"] = MenuSelection.Login,
         ["Dashboard"] = MenuSelection.Dashboard,
         ["Elevator Control"] = MenuSelection.ElevatorControl,
+        ["Multi Request Elevator Control"] = MenuSelection.MultiElevatorControl,
+        ["Login"] = MenuSelection.Login,
         ["Exit"] = MenuSelection.Exit
-        
     };
 
     public async Task<Result<MenuSelection>> ShowAsync(CancellationToken token)


### PR DESCRIPTION
Introduces a new option for multi-request elevator control in the menu. The `MenuSelection` enum is updated to include `MultiElevatorControl`, and a new `ElevatorControlMultipleRequestScreen` is implemented to handle multiple elevator requests through user input. This enhances user functionality by allowing simultaneous requests for elevators.